### PR TITLE
Support refreshing only displaying view nodes. 支持仅刷新可见视图节点

### DIFF
--- a/LookinClient/Hierarchy/LKHierarchyDataSource.h
+++ b/LookinClient/Hierarchy/LKHierarchyDataSource.h
@@ -114,4 +114,6 @@ typedef NS_ENUM(NSUInteger, LKHierarchyDataSourceState) {
 - (void)focusDisplayItem:(LookinDisplayItem *)item;
 - (void)endFocus;
 
+- (void)reloadWithItems:(NSArray<LookinDisplayItem *> *)items;
+
 @end

--- a/LookinClient/Hierarchy/LKHierarchyDataSource.h
+++ b/LookinClient/Hierarchy/LKHierarchyDataSource.h
@@ -114,6 +114,6 @@ typedef NS_ENUM(NSUInteger, LKHierarchyDataSourceState) {
 - (void)focusDisplayItem:(LookinDisplayItem *)item;
 - (void)endFocus;
 
-- (void)reloadWithItems:(NSArray<LookinDisplayItem *> *)items;
+- (void)reloadWithItems:(NSArray<LookinDisplayItem *> *)items forced:(BOOL)forced;
 
 @end

--- a/LookinClient/Hierarchy/LKHierarchyDataSource.m
+++ b/LookinClient/Hierarchy/LKHierarchyDataSource.m
@@ -551,6 +551,9 @@
     }
     item.isExpanded = NO;
     [self buildDisplayingFlatItems];
+    if ([LKPreferenceManager mainManager].refreshMode == LookinRefreshModeDisplayingItems) {
+        [self reloadWithItems:self.displayingFlatItems forced:NO];
+    }
 }
 
 - (void)expandItem:(LookinDisplayItem *)item {
@@ -562,6 +565,9 @@
     }
     item.isExpanded = YES;
     [self buildDisplayingFlatItems];
+    if ([LKPreferenceManager mainManager].refreshMode == LookinRefreshModeDisplayingItems) {
+        [self reloadWithItems:self.displayingFlatItems forced:NO];
+    }
 }
 
 - (void)expandToShowItem:(LookinDisplayItem *)item {
@@ -572,6 +578,9 @@
     }];
     
     [self buildDisplayingFlatItems];
+    if ([LKPreferenceManager mainManager].refreshMode == LookinRefreshModeDisplayingItems) {
+        [self reloadWithItems:self.displayingFlatItems forced:NO];
+    }
 }
 
 - (void)expandItemsRootedByItem:(LookinDisplayItem *)item {
@@ -590,6 +599,9 @@
     }
     
     [self buildDisplayingFlatItems];
+    if ([LKPreferenceManager mainManager].refreshMode == LookinRefreshModeDisplayingItems) {
+        [self reloadWithItems:self.displayingFlatItems forced:NO];
+    }
 }
 
 - (void)collapseAllChildrenOfItem:(LookinDisplayItem *)item {
@@ -606,6 +618,9 @@
         enumeratedItem.isExpanded = NO;
     }];
     [self buildDisplayingFlatItems];
+    if ([LKPreferenceManager mainManager].refreshMode == LookinRefreshModeDisplayingItems) {
+        [self reloadWithItems:self.displayingFlatItems forced:NO];
+    }
 }
 
 - (void)reloadWithItems:(NSArray<LookinDisplayItem *> *)items forced:(BOOL)forced {}

--- a/LookinClient/Hierarchy/LKHierarchyDataSource.m
+++ b/LookinClient/Hierarchy/LKHierarchyDataSource.m
@@ -608,7 +608,7 @@
     [self buildDisplayingFlatItems];
 }
 
-- (void)reloadWithItems:(NSArray<LookinDisplayItem *> *)items {}
+- (void)reloadWithItems:(NSArray<LookinDisplayItem *> *)items forced:(BOOL)forced {}
 
 #pragma mark - Search
 

--- a/LookinClient/Hierarchy/LKHierarchyDataSource.m
+++ b/LookinClient/Hierarchy/LKHierarchyDataSource.m
@@ -608,6 +608,8 @@
     [self buildDisplayingFlatItems];
 }
 
+- (void)reloadWithItems:(NSArray<LookinDisplayItem *> *)items {}
+
 #pragma mark - Search
 
 - (void)searchWithString:(NSString *)string {

--- a/LookinClient/Hierarchy/LKHierarchyView.m
+++ b/LookinClient/Hierarchy/LKHierarchyView.m
@@ -172,7 +172,9 @@ extern NSString *const LKAppShowConsoleNotificationName;
     } else {
         self.emptyDataLabel.hidden = YES;
     }
-    [self.dataSource reloadWithItems:displayItems];
+    if ([LKPreferenceManager mainManager].refreshMode == LookinRefreshModeDisplayingItems) {
+        [self.dataSource reloadWithItems:displayItems forced:NO];
+    }
 }
 
 - (void)scrollToMakeItemVisible:(LookinDisplayItem *)item {
@@ -299,7 +301,16 @@ extern NSString *const LKAppShowConsoleNotificationName;
             item.title = NSLocalizedString(@"Print", nil);
             item;
         })];
-        [menu addItem:[NSMenuItem separatorItem]];        
+        [menu addItem:[NSMenuItem separatorItem]];     
+        
+        [menu addItem:({
+            NSMenuItem *item = [NSMenuItem new];
+            item.target = self;
+            item.action = @selector(_handleRefreshItem:);
+            item.title = NSLocalizedString(@"Refresh", nil);
+            item;
+        })];
+        [menu addItem:[NSMenuItem separatorItem]];
     }
 
     if (displayItem.isExpandable) {
@@ -432,6 +443,19 @@ extern NSString *const LKAppShowConsoleNotificationName;
     LKHierarchyRowView *view = [menuItem.menu lookin_getBindObjectForKey:kMenuBindKey_RowView];
     LookinDisplayItem *item = view.displayItem;
     [[NSNotificationCenter defaultCenter] postNotificationName:LKAppShowConsoleNotificationName object:item];
+}
+
+- (void)_handleRefreshItem:(NSMenuItem *)menuItem {
+    LKHierarchyRowView *view = [menuItem.menu lookin_getBindObjectForKey:kMenuBindKey_RowView];
+    LookinDisplayItem *item = view.displayItem;
+    NSMutableArray *items = [NSMutableArray array];
+    BOOL allNodesRefresh = [LKPreferenceManager mainManager].refreshMode == LookinRefreshModeAllItems;
+    [item enumerateSelfAndChildren:^(LookinDisplayItem * _Nonnull item) {
+        if (allNodesRefresh || item.displayingInHierarchy) {
+            [items addObject:item];
+        }
+    }];
+    [self.dataSource reloadWithItems:items forced:YES];
 }
 
 - (void)_handleFocusCurrentItem:(NSMenuItem *)menuItem {

--- a/LookinClient/Hierarchy/LKHierarchyView.m
+++ b/LookinClient/Hierarchy/LKHierarchyView.m
@@ -172,9 +172,6 @@ extern NSString *const LKAppShowConsoleNotificationName;
     } else {
         self.emptyDataLabel.hidden = YES;
     }
-    if ([LKPreferenceManager mainManager].refreshMode == LookinRefreshModeDisplayingItems) {
-        [self.dataSource reloadWithItems:displayItems forced:NO];
-    }
 }
 
 - (void)scrollToMakeItemVisible:(LookinDisplayItem *)item {

--- a/LookinClient/Hierarchy/LKHierarchyView.m
+++ b/LookinClient/Hierarchy/LKHierarchyView.m
@@ -172,6 +172,7 @@ extern NSString *const LKAppShowConsoleNotificationName;
     } else {
         self.emptyDataLabel.hidden = YES;
     }
+    [self.dataSource reloadWithItems:displayItems];
 }
 
 - (void)scrollToMakeItemVisible:(LookinDisplayItem *)item {

--- a/LookinClient/Manager/LKPreferenceManager.h
+++ b/LookinClient/Manager/LKPreferenceManager.h
@@ -29,6 +29,11 @@ typedef NS_ENUM(NSInteger, LookinDoubleClickBehavior) {
     LookinDoubleClickBehaviorFocus
 };
 
+typedef NS_ENUM(NSInteger, LookinRefreshMode) {
+    LookinRefreshModeAllItems,
+    LookinRefreshModeDisplayingItems
+};
+
 typedef NS_ENUM(NSInteger, LookinPreferredCallStackType) {
     LookinPreferredCallStackTypeDefault,    // 格式化 + 简略
     LookinPreferredCallStackTypeFormattedCompletely, // 格式化 + 完整
@@ -52,6 +57,8 @@ typedef NS_ENUM(NSInteger, LookinMeasureState) {
 @property(nonatomic, assign) LookinPreferredAppeanranceType appearanceType;
 
 @property(nonatomic, assign) LookinDoubleClickBehavior doubleClickBehavior;
+
+@property(nonatomic, assign) LookinRefreshMode refreshMode;
 
 /// 有效值为 0 ～ 4
 @property(nonatomic, assign) NSInteger expansionIndex;

--- a/LookinClient/Manager/LKPreferenceManager.m
+++ b/LookinClient/Manager/LKPreferenceManager.m
@@ -28,6 +28,7 @@ static NSString * const Key_RgbaFormat = @"egbaFormat";
 static NSString * const Key_ZInterspace = @"zInterspace_v095";
 static NSString * const Key_AppearanceType = @"appearanceType";
 static NSString * const Key_DoubleClickBehavior = @"doubleClickBehavior";
+static NSString * const Key_RefreshMode = @"refreshMode";
 static NSString * const Key_ExpansionIndex = @"expansionIndex";
 static NSString * const Key_ContrastLevel = @"contrastLevel";
 static NSString * const Key_SectionsShow = @"ss";
@@ -106,6 +107,14 @@ static NSString * const Key_ReceivingConfigTime_Class = @"ConfigTime_Class";
         } else {
             _doubleClickBehavior = LookinDoubleClickBehaviorCollapse;
             [userDefaults setObject:@(_doubleClickBehavior) forKey:Key_DoubleClickBehavior];
+        }
+        
+        NSNumber *obj_refreshMode = [userDefaults objectForKey:Key_RefreshMode];
+        if (obj_refreshMode) {
+            _refreshMode = [obj_refreshMode intValue];
+        } else {
+            _refreshMode = LookinRefreshModeAllItems;
+            [userDefaults setObject:@(_refreshMode) forKey:Key_RefreshMode];
         }
         
         NSNumber *obj_rgbaFormat = [userDefaults objectForKey:Key_RgbaFormat];
@@ -233,6 +242,13 @@ static NSString * const Key_ReceivingConfigTime_Class = @"ConfigTime_Class";
     _doubleClickBehavior = doubleClickBehavior;
     if (self.shouldStoreToLocal) {
         [[NSUserDefaults standardUserDefaults] setObject:@(doubleClickBehavior) forKey:Key_DoubleClickBehavior];
+    }
+}
+
+- (void)setRefreshMode:(LookinRefreshMode)refreshMode {
+    _refreshMode = refreshMode;
+    if (self.shouldStoreToLocal) {
+        [[NSUserDefaults standardUserDefaults] setObject:@(refreshMode) forKey:Key_RefreshMode];
     }
 }
 

--- a/LookinClient/Preference/LKPreferenceViewController.m
+++ b/LookinClient/Preference/LKPreferenceViewController.m
@@ -18,6 +18,7 @@
 @property(nonatomic, strong) LKPreferencePopupView *view_doubleClick;
 @property(nonatomic, strong) LKPreferencePopupView *view_appearance;
 @property(nonatomic, strong) LKPreferencePopupView *view_colorFormat;
+@property(nonatomic, strong) LKPreferencePopupView *view_refreshMode;
 @property(nonatomic, strong) LKPreferenceSwitchView *view_enableLog;
 @property(nonatomic, strong) LKPreferencePopupView *view_contrast;
 
@@ -65,6 +66,14 @@
     };
     [self.view addSubview:self.view_doubleClick];
     
+    NSString *refreshTips = NSLocalizedString(@"Choosing to refresh only visible view nodes can significantly improve the loading speed.", nil);
+    self.view_refreshMode = [[LKPreferencePopupView alloc] initWithTitle:NSLocalizedString(@"Refresh mode", nil) message:refreshTips options:@[NSLocalizedString(@"Refresh all view nodes immediately", nil), NSLocalizedString(@"Refresh only visible view nodes", nil)]];
+    self.view_refreshMode.buttonX = controlX;
+    self.view_refreshMode.didChange = ^(NSUInteger selectedIndex) {
+        [LKPreferenceManager mainManager].refreshMode = selectedIndex;
+    };
+    [self.view addSubview:self.view_refreshMode];
+    
     self.view_enableLog = [[LKPreferenceSwitchView alloc] initWithTitle:NSLocalizedString(@"Share analytics with Lookin", nil) message:NSLocalizedString(@"Help to improve Lookin by automatically sending diagnostics and usage data.", nil)];
     self.view_enableLog.didChange = ^(BOOL isChecked) {
         [LKPreferenceManager mainManager].enableReport = isChecked;
@@ -93,6 +102,7 @@
 
     self.view_appearance.selectedIndex = manager.appearanceType;
     self.view_doubleClick.selectedIndex = manager.doubleClickBehavior;
+    self.view_refreshMode.selectedIndex = manager.refreshMode;
     self.view_enableLog.isChecked = manager.enableReport;
 }
 
@@ -107,8 +117,9 @@
     $(self.view_contrast).x(insets.left).toRight(insets.right).y(self.view_colorFormat.$maxY).height(65);
     
     $(self.view_doubleClick).x(insets.left).toRight(insets.right).y(self.view_contrast.$maxY).height(50);
+    $(self.view_refreshMode).x(insets.left).toRight(insets.right).y(self.view_doubleClick.$maxY).height(65);
     
-    __block CGFloat y = self.view_doubleClick.$maxY;
+    __block CGFloat y = self.view_refreshMode.$maxY;
     [$(self.view_enableLog).array enumerateObjectsUsingBlock:^(NSView *  _Nonnull view, NSUInteger idx, BOOL * _Nonnull stop) {
         $(view).x(115).toRight(insets.right).y(y).heightToFit;
         y = view.$maxY + 5;
@@ -124,6 +135,7 @@
     manager.enableReport = YES;
     manager.rgbaFormat = YES;
     manager.doubleClickBehavior = LookinDoubleClickBehaviorCollapse;
+    manager.refreshMode = LookinRefreshModeAllItems;
     manager.imageContrastLevel = 0;
     [self renderFromPreferenceManager];
     

--- a/LookinClient/Preference/LKPreferenceViewController.m
+++ b/LookinClient/Preference/LKPreferenceViewController.m
@@ -66,7 +66,7 @@
     };
     [self.view addSubview:self.view_doubleClick];
     
-    NSString *refreshTips = NSLocalizedString(@"Choosing to refresh only visible view nodes can significantly improve the loading speed.", nil);
+    NSString *refreshTips = NSLocalizedString(@"Choosing to refresh only visible view nodes can significantly improve the loading speed. However, in some scenarios, it may display abnormally.", nil);
     self.view_refreshMode = [[LKPreferencePopupView alloc] initWithTitle:NSLocalizedString(@"Refresh mode", nil) message:refreshTips options:@[NSLocalizedString(@"Refresh all view nodes immediately", nil), NSLocalizedString(@"Refresh only visible view nodes", nil)]];
     self.view_refreshMode.buttonX = controlX;
     self.view_refreshMode.didChange = ^(NSUInteger selectedIndex) {
@@ -117,7 +117,7 @@
     $(self.view_contrast).x(insets.left).toRight(insets.right).y(self.view_colorFormat.$maxY).height(65);
     
     $(self.view_doubleClick).x(insets.left).toRight(insets.right).y(self.view_contrast.$maxY).height(50);
-    $(self.view_refreshMode).x(insets.left).toRight(insets.right).y(self.view_doubleClick.$maxY).height(65);
+    $(self.view_refreshMode).x(insets.left).toRight(insets.right).y(self.view_doubleClick.$maxY).height(80);
     
     __block CGFloat y = self.view_refreshMode.$maxY;
     [$(self.view_enableLog).array enumerateObjectsUsingBlock:^(NSView *  _Nonnull view, NSUInteger idx, BOOL * _Nonnull stop) {

--- a/LookinClient/Preference/LKPreferenceWindowController.m
+++ b/LookinClient/Preference/LKPreferenceWindowController.m
@@ -13,7 +13,7 @@
 @implementation LKPreferenceWindowController
 
 - (instancetype)init {
-    LKWindow *window = [[LKWindow alloc] initWithContentRect:NSMakeRect(0, 0, 600, 380) styleMask:NSWindowStyleMaskTitled|NSWindowStyleMaskClosable|NSWindowStyleMaskMiniaturizable backing:NSBackingStoreBuffered defer:YES];
+    LKWindow *window = [[LKWindow alloc] initWithContentRect:NSMakeRect(0, 0, 600, 450) styleMask:NSWindowStyleMaskTitled|NSWindowStyleMaskClosable|NSWindowStyleMaskMiniaturizable backing:NSBackingStoreBuffered defer:YES];
     window.movableByWindowBackground = YES;
     window.title = NSLocalizedString(@"Preferences", nil);
     [window center];

--- a/LookinClient/Static/LKStaticAsyncUpdateManager.h
+++ b/LookinClient/Static/LKStaticAsyncUpdateManager.h
@@ -19,7 +19,7 @@
 /// 终止拉取
 - (void)endUpdatingAll;
 /// 部分刷新
-- (BOOL)updateForItemIfNeed:(LookinDisplayItem *)item;
+- (BOOL)updateForItemsIfNeed:(NSArray<LookinDisplayItem *> *)item;
 /// 调用 updateAll 后，该 signal 会不断发出信号。data 是 RACTuple，tuple.first 是 NSNumber，表示已经收到的数据总数，tuple.second 也是 NSNumber，表示预期会接收到的数据总数
 @property(nonatomic, strong, readonly) RACSubject *updateAll_ProgressSignal;
 /// 调用 updateAll 且数据全部接收完成后，或遇到 error 会发出该信号

--- a/LookinClient/Static/LKStaticAsyncUpdateManager.h
+++ b/LookinClient/Static/LKStaticAsyncUpdateManager.h
@@ -18,6 +18,8 @@
 - (void)updateAll;
 /// 终止拉取
 - (void)endUpdatingAll;
+/// 部分刷新
+- (BOOL)updateForItemIfNeed:(LookinDisplayItem *)item;
 /// 调用 updateAll 后，该 signal 会不断发出信号。data 是 RACTuple，tuple.first 是 NSNumber，表示已经收到的数据总数，tuple.second 也是 NSNumber，表示预期会接收到的数据总数
 @property(nonatomic, strong, readonly) RACSubject *updateAll_ProgressSignal;
 /// 调用 updateAll 且数据全部接收完成后，或遇到 error 会发出该信号

--- a/LookinClient/Static/LKStaticAsyncUpdateManager.h
+++ b/LookinClient/Static/LKStaticAsyncUpdateManager.h
@@ -19,7 +19,7 @@
 /// 终止拉取
 - (void)endUpdatingAll;
 /// 部分刷新
-- (BOOL)updateForItemsIfNeed:(NSArray<LookinDisplayItem *> *)item;
+- (BOOL)updateForItemsIfNeed:(NSArray<LookinDisplayItem *> *)item forced:(BOOL)forced;
 /// 调用 updateAll 后，该 signal 会不断发出信号。data 是 RACTuple，tuple.first 是 NSNumber，表示已经收到的数据总数，tuple.second 也是 NSNumber，表示预期会接收到的数据总数
 @property(nonatomic, strong, readonly) RACSubject *updateAll_ProgressSignal;
 /// 调用 updateAll 且数据全部接收完成后，或遇到 error 会发出该信号

--- a/LookinClient/Static/LKStaticAsyncUpdateManager.m
+++ b/LookinClient/Static/LKStaticAsyncUpdateManager.m
@@ -107,13 +107,13 @@
     }];
 }
 
-- (BOOL)updateForItemsIfNeed:(NSArray<LookinDisplayItem *> *)items {
+- (BOOL)updateForItemsIfNeed:(NSArray<LookinDisplayItem *> *)items forced:(BOOL)forced {
     LKInspectableApp *app = [LKAppsManager sharedInstance].inspectingApp;
     if (!app || !self.dataSource.flatItems.count) {
         return NO;
     }
     
-    NSArray<LookinStaticAsyncUpdateTask *> *tasks = [self _makeScreenshotsAndAttrGroupsTasksByItems:items];
+    NSArray<LookinStaticAsyncUpdateTask *> *tasks = [self _makeScreenshotsAndAttrGroupsTasksByItems:items forced:forced];
     if (tasks.count == 0) {
         return NO;
     }
@@ -211,14 +211,18 @@
     return tasks.copy;
 }
 
-- (NSArray<LookinStaticAsyncUpdateTask *> *)_makeScreenshotsAndAttrGroupsTasksByItems:(NSArray<LookinDisplayItem *> *)items {
+- (NSArray<LookinStaticAsyncUpdateTask *> *)_makeScreenshotsAndAttrGroupsTasksByItems:(NSArray<LookinDisplayItem *> *)items forced:(BOOL)forced {
     NSArray<LookinStaticAsyncUpdateTask *> *tasks = [items lookin_map:^id(NSUInteger idx, LookinDisplayItem *item) {
-        if (item.isUserCustom
-            || (item.soloScreenshot != nil && item.isExpanded)
-            || (item.groupScreenshot != nil && !item.isExpanded)
-            || !item.shouldCaptureImage
-            || (item.frame.size.width == 0 || item.frame.size.height == 0)) {
+        if (item.isUserCustom) {
             return nil;
+        }
+        if (!forced) {
+            if ((item.soloScreenshot != nil && item.isExpanded)
+                || (item.groupScreenshot != nil && !item.isExpanded)
+                || !item.shouldCaptureImage
+                || (item.frame.size.width == 0 || item.frame.size.height == 0)) {
+                return nil;
+            }
         }
         if (item.doNotFetchScreenshotReason == LookinFetchScreenshotPermitted) {
             if (item.isExpandable && item.isExpanded) {

--- a/LookinClient/Static/LKStaticAsyncUpdateManager.m
+++ b/LookinClient/Static/LKStaticAsyncUpdateManager.m
@@ -106,13 +106,13 @@
     }];
 }
 
-- (BOOL)updateForItemIfNeed:(LookinDisplayItem *)item {
+- (BOOL)updateForItemsIfNeed:(NSArray<LookinDisplayItem *> *)items {
     LKInspectableApp *app = [LKAppsManager sharedInstance].inspectingApp;
     if (!app || !self.dataSource.flatItems.count) {
         return NO;
     }
     
-    NSArray<LookinStaticAsyncUpdateTask *> *tasks = [self _makeScreenshotsAndAttrGroupsTasksByItem:item];
+    NSArray<LookinStaticAsyncUpdateTask *> *tasks = [self _makeScreenshotsAndAttrGroupsTasksByItems:items];
     if (tasks.count == 0) {
         return NO;
     }
@@ -183,9 +183,9 @@
     return tasks.copy;
 }
 
-- (NSArray<LookinStaticAsyncUpdateTask *> *)_makeScreenshotsAndAttrGroupsTasksByItem:(LookinDisplayItem *)item {
-    NSArray<LookinStaticAsyncUpdateTask *> *tasks = [(NSArray<LookinDisplayItem *> *)item.subitems lookin_map:^id(NSUInteger idx, LookinDisplayItem *item) {
-        if (item.isUserCustom 
+- (NSArray<LookinStaticAsyncUpdateTask *> *)_makeScreenshotsAndAttrGroupsTasksByItems:(NSArray<LookinDisplayItem *> *)items {
+    NSArray<LookinStaticAsyncUpdateTask *> *tasks = [items lookin_map:^id(NSUInteger idx, LookinDisplayItem *item) {
+        if (item.isUserCustom
             || (item.soloScreenshot != nil || item.groupScreenshot != nil)
             || !item.shouldCaptureImage
             || (item.frame.size.width == 0 || item.frame.size.height == 0)) {

--- a/LookinClient/Static/LKStaticAsyncUpdateManager.m
+++ b/LookinClient/Static/LKStaticAsyncUpdateManager.m
@@ -109,7 +109,7 @@
 
 - (BOOL)updateForItemsIfNeed:(NSArray<LookinDisplayItem *> *)items forced:(BOOL)forced {
     LKInspectableApp *app = [LKAppsManager sharedInstance].inspectingApp;
-    if (!app || !self.dataSource.flatItems.count) {
+    if (!app || !self.dataSource.flatItems.count || self.isSyncing) {
         return NO;
     }
     

--- a/LookinClient/Static/LKStaticHierarchyDataSource.m
+++ b/LookinClient/Static/LKStaticHierarchyDataSource.m
@@ -182,4 +182,12 @@
     return isNew;
 }
 
+#pragma mark - override
+- (void)expandItem:(LookinDisplayItem *)item {
+    [super expandItem:item];
+    if (item.isExpanded && [[LKStaticAsyncUpdateManager sharedInstance] updateForItemIfNeed:item]) {
+        [self updateMessageStatus];
+    }
+}
+
 @end

--- a/LookinClient/Static/LKStaticHierarchyDataSource.m
+++ b/LookinClient/Static/LKStaticHierarchyDataSource.m
@@ -183,9 +183,8 @@
 }
 
 #pragma mark - override
-- (void)expandItem:(LookinDisplayItem *)item {
-    [super expandItem:item];
-    if (item.isExpanded && [[LKStaticAsyncUpdateManager sharedInstance] updateForItemIfNeed:item]) {
+- (void)reloadWithItems:(NSArray<LookinDisplayItem *> *)items {
+    if ([[LKStaticAsyncUpdateManager sharedInstance] updateForItemsIfNeed:items]) {
         [self updateMessageStatus];
     }
 }

--- a/LookinClient/Static/LKStaticHierarchyDataSource.m
+++ b/LookinClient/Static/LKStaticHierarchyDataSource.m
@@ -19,6 +19,7 @@
 #import "LKMessageManager.h"
 #import "LKServerVersionRequestor.h"
 #import "LKVersionComparer.h"
+#import "LKPreferenceManager.h"
 @import AppCenter;
 @import AppCenterAnalytics;
 
@@ -184,7 +185,7 @@
 
 #pragma mark - override
 - (void)reloadWithItems:(NSArray<LookinDisplayItem *> *)items {
-    if ([[LKStaticAsyncUpdateManager sharedInstance] updateForItemsIfNeed:items]) {
+    if ([LKPreferenceManager mainManager].refreshMode == LookinRefreshModeDisplayingItems && [[LKStaticAsyncUpdateManager sharedInstance] updateForItemsIfNeed:items]) {
         [self updateMessageStatus];
     }
 }

--- a/LookinClient/Static/LKStaticHierarchyDataSource.m
+++ b/LookinClient/Static/LKStaticHierarchyDataSource.m
@@ -19,7 +19,6 @@
 #import "LKMessageManager.h"
 #import "LKServerVersionRequestor.h"
 #import "LKVersionComparer.h"
-#import "LKPreferenceManager.h"
 @import AppCenter;
 @import AppCenterAnalytics;
 
@@ -184,8 +183,8 @@
 }
 
 #pragma mark - override
-- (void)reloadWithItems:(NSArray<LookinDisplayItem *> *)items {
-    if ([LKPreferenceManager mainManager].refreshMode == LookinRefreshModeDisplayingItems && [[LKStaticAsyncUpdateManager sharedInstance] updateForItemsIfNeed:items]) {
+- (void)reloadWithItems:(NSArray<LookinDisplayItem *> *)items forced:(BOOL)forced {
+    if ([[LKStaticAsyncUpdateManager sharedInstance] updateForItemsIfNeed:items forced:forced]) {
         [self updateMessageStatus];
     }
 }

--- a/LookinClient/Static/Preview/LKPreviewController.m
+++ b/LookinClient/Static/Preview/LKPreviewController.m
@@ -653,7 +653,16 @@ extern NSString *const LKAppShowConsoleNotificationName;
             item.title = NSLocalizedString(@"Print", nil);
             item;
         })];
-        [menu addItem:[NSMenuItem separatorItem]];        
+        [menu addItem:[NSMenuItem separatorItem]];   
+        
+        [menu addItem:({
+            NSMenuItem *item = [NSMenuItem new];
+            item.target = self;
+            item.action = @selector(_handleRefreshItem:);
+            item.title = NSLocalizedString(@"Refresh", nil);
+            item;
+        })];
+        [menu addItem:[NSMenuItem separatorItem]];
     }
 
     if (displayItem.isExpandable) {
@@ -719,6 +728,18 @@ extern NSString *const LKAppShowConsoleNotificationName;
 - (void)_handlePrintItem:(NSMenuItem *)menuItem {
     LookinDisplayItem *item = self.rightClickingDisplayItem;
     [[NSNotificationCenter defaultCenter] postNotificationName:LKAppShowConsoleNotificationName object:item];
+}
+
+- (void)_handleRefreshItem:(NSMenuItem *)menuItem {
+    LookinDisplayItem *item = self.rightClickingDisplayItem;
+    NSMutableArray *items = [NSMutableArray array];
+    BOOL allNodesRefresh = [LKPreferenceManager mainManager].refreshMode == LookinRefreshModeAllItems;
+    [item enumerateSelfAndChildren:^(LookinDisplayItem * _Nonnull item) {
+        if (allNodesRefresh || item.displayingInHierarchy) {
+            [items addObject:item];
+        }
+    }];
+    [self.dataSource reloadWithItems:items forced:YES];
 }
 
 - (void)_handleFocusCurrentItem:(NSMenuItem *)menuItem {

--- a/LookinClient/en.lproj/Localizable.strings
+++ b/LookinClient/en.lproj/Localizable.strings
@@ -21,7 +21,11 @@
 "Preferences" = "Preferences";
 "Appearance" = "Appearance";
 "Double click" = "Double click";
+"Refresh mode" = "Refresh mode";
 "Expand or collapse layer" = "Expand or collapse layer";
+"Refresh all view nodes immediately" = "Refresh all view nodes immediately";
+"Refresh only visible view nodes" = "Refresh only visible view nodes";
+"Choosing to refresh only visible view nodes can significantly improve the loading speed." = "Choosing to refresh only visible view nodes can significantly improve the loading speed.";
 "Focus on layer" = "Focus on layer";
 "Dark Mode" = "Dark Mode";
 "Light Mode" = "Light Mode";

--- a/LookinClient/en.lproj/Localizable.strings
+++ b/LookinClient/en.lproj/Localizable.strings
@@ -45,6 +45,7 @@
 "Expand recursively" = "Expand recursively";
 "Collapse children" = "Collapse children";
 "Focus" = "Focus";
+"Refresh" = "Refresh";
 "Print" = "Print";
 "Hide screenshot this time" = "Hide screenshot this time";
 "Hide screenshot forever…" = "Hide screenshot forever…";

--- a/LookinClient/en.lproj/Localizable.strings
+++ b/LookinClient/en.lproj/Localizable.strings
@@ -25,7 +25,7 @@
 "Expand or collapse layer" = "Expand or collapse layer";
 "Refresh all view nodes immediately" = "Refresh all view nodes immediately";
 "Refresh only visible view nodes" = "Refresh only visible view nodes";
-"Choosing to refresh only visible view nodes can significantly improve the loading speed." = "Choosing to refresh only visible view nodes can significantly improve the loading speed.";
+"Choosing to refresh only visible view nodes can significantly improve the loading speed. However, in some scenarios, it may display abnormally." = "Choosing to refresh only visible view nodes can significantly improve the loading speed. However, in some scenarios, it may display abnormally.";
 "Focus on layer" = "Focus on layer";
 "Dark Mode" = "Dark Mode";
 "Light Mode" = "Light Mode";

--- a/LookinClient/zh-Hans.lproj/Localizable.strings
+++ b/LookinClient/zh-Hans.lproj/Localizable.strings
@@ -47,6 +47,7 @@
 "Expand recursively" = "全部展开";
 "Collapse children" = "收起子图层";
 "Focus" = "聚焦";
+"Refresh" = "刷新";
 "Print" = "打印";
 "Hide screenshot this time" = "隐藏图像（仅本次）";
 "Hide screenshot forever…" = "永久隐藏图像…";

--- a/LookinClient/zh-Hans.lproj/Localizable.strings
+++ b/LookinClient/zh-Hans.lproj/Localizable.strings
@@ -21,9 +21,13 @@
 "Preferences" = "偏好设置";
 "Appearance" = "外观";
 "Double click" = "双击图层";
+"Refresh mode" = "刷新模式";
 "Image contrast" = "图像对比度";
 "Adjust this option to use a deeper layer selection color." = "调整该选项以使用更深的图层选中色";
 "Expand or collapse layer" = "展开或折叠";
+"Refresh all view nodes immediately" = "立即刷新所有视图节点";
+"Refresh only visible view nodes" = "只刷新可见的视图节点";
+"Choosing to refresh only visible view nodes can significantly improve the loading speed." = "选择只刷新可见视图节点的模式可以明显提高视图加载速度";
 "Focus on layer" = "聚焦";
 "Dark Mode" = "深色";
 "Light Mode" = "浅色";

--- a/LookinClient/zh-Hans.lproj/Localizable.strings
+++ b/LookinClient/zh-Hans.lproj/Localizable.strings
@@ -27,7 +27,7 @@
 "Expand or collapse layer" = "展开或折叠";
 "Refresh all view nodes immediately" = "立即刷新所有视图节点";
 "Refresh only visible view nodes" = "只刷新可见的视图节点";
-"Choosing to refresh only visible view nodes can significantly improve the loading speed." = "选择只刷新可见视图节点的模式可以明显提高视图加载速度";
+"Choosing to refresh only visible view nodes can significantly improve the loading speed. However, in some scenarios, it may display abnormally." = "选择只刷新可见视图节点的模式可以明显提高视图加载速度, 但在部分场景下可能显示异常.";
 "Focus on layer" = "聚焦";
 "Dark Mode" = "深色";
 "Light Mode" = "浅色";


### PR DESCRIPTION
Currently, Lookin's view refresh mode is full refresh, but in reality, most of the view nodes are not in displaying. When there are a large number of view nodes, full refresh will lead to excessively long refresh times.
Changes:
1. Add a setting option for 'Refresh Mode', supporting the option to refresh only displaying view nodes.
2. Support refreshing single view nodes.
3. Expanding or collapsing the view tree will trigger a view refresh.

Actual tests show that it can improve loading speed by at least 90%.

目前Lookin的视图刷新模式是全量刷新, 但实际上大部分的视图节点并不会关注到. 在视图节点数量很多的时候, 全量刷新就会导致刷新时间过长.
变更内容:
1. 新增"刷新模式"的设置项, 支持设置仅刷新可见视图节点.
2. 支持对单个视图节点刷新
3. 在视图树展开或折叠的时候会触发视图刷新.

实际测试可以提高至少90%的加载速度.

![image](https://github.com/hughkli/Lookin/assets/5734060/eb15ed5b-31bc-4cb6-aa2a-8b1c4a0d8b16)
